### PR TITLE
Creating a new extension for Close Other Tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # Close Tabs to the Right
-This WebExtension (re)adds a context menu option to browser tabs to close tabs to the right of the selected one.
-Tested on Firefox 55.
+This WebExtension (re)adds a context menu option to browser tabs to close other tabs other than the selected one that was [removed in Firefox 78](https://support.mozilla.org/en-US/kb/changes-tab-context-menu-firefox-78).
+Tested on Firefox 78.0.1.
+[Becuase Firefox only allows one menu item per exention in the root context menu](https://bugzilla.mozilla.org/show_bug.cgi?id=1294429), separate extensions are needed for each item.

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -12,5 +12,10 @@
   "contextItemTitle": {
       "message": "Close Tabs to the Right",
       "description": "Title of the context menu item."
+  },
+
+  "contextItemTitleCloseOtherTabs": {
+      "message": "Close Other Tabs",
+      "description": "Title of the context menu item that closes other tabs."
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,6 +1,6 @@
 {
   "extensionName": {
-    "message": "Close Tabs to the Right",
+    "message": "Close Other Tabs",
     "description": "Name of the extension."
   },
 

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -1,6 +1,6 @@
 {
     "extensionName": {
-      "message": "Zamknij karty po prawej stronie",
+      "message": "Zamknij inne zakładki",
       "description": "Nazwa rozszerzenia."
     },
 

--- a/background.js
+++ b/background.js
@@ -13,6 +13,14 @@ const menuItemParams = {
 };
 browser.contextMenus.create(menuItemParams, onCreated);
 
+// Add Close Other Tabs menu item
+const menuItemParamsCloseOtherTabs = {
+  id: "close_other_tabs",
+  title: browser.i18n.getMessage("contextItemTitleCloseOtherTabs"),
+  contexts: ["tab"]
+};
+browser.contextMenus.create(menuItemParamsCloseOtherTabs, onCreated);
+
 function closeTabs(sender, tabs) {
     var senderFound = false;
     for (var tab of tabs) {
@@ -26,10 +34,24 @@ function closeTabs(sender, tabs) {
     }
 }
 
+function closeOtherTabs(sender, tabs) {
+    for (var tab of tabs) {
+        if (tab.id == sender.id) {
+            continue;
+        } else if (!tab.pinned) {
+            browser.tabs.remove(tab.id);
+        }
+    }
+}
+
 browser.contextMenus.onClicked.addListener(function(info, sender) {
     var querying = browser.tabs.query({currentWindow: true});
 
-    querying.then(closeTabs.bind(null, sender));
+    if (info.menuItemId == "close_right") {
+        querying.then(closeTabs.bind(null, sender));
+    } else if (info.menuItemId == "close_other_tabs") {
+        querying.then(closeOtherTabs.bind(null, sender));
+    }
 });
 
 

--- a/background.js
+++ b/background.js
@@ -6,20 +6,21 @@ function onCreated(n) {
   }
 }
 
-const menuItemParams = {
-  id: "close_right",
-  title: browser.i18n.getMessage("contextItemTitle"),
-  contexts: ["tab"]
-};
-browser.contextMenus.create(menuItemParams, onCreated);
-
-// Add Close Other Tabs menu item
-const menuItemParamsCloseOtherTabs = {
-  id: "close_other_tabs",
-  title: browser.i18n.getMessage("contextItemTitleCloseOtherTabs"),
-  contexts: ["tab"]
-};
-browser.contextMenus.create(menuItemParamsCloseOtherTabs, onCreated);
+if (browser.i18n.getMessage("extensionName") == "Close Tabs to the Right") {
+    const menuItemParams = {
+      id: "close_right",
+      title: browser.i18n.getMessage("contextItemTitle"),
+      contexts: ["tab"]
+    };
+    browser.contextMenus.create(menuItemParams, onCreated);
+} else if (browser.i18n.getMessage("extensionName") == "Close Other Tabs") {
+    const menuItemParams = {
+      id: "close_other_tabs",
+      title: browser.i18n.getMessage("contextItemTitleCloseOtherTabs"),
+      contexts: ["tab"]
+    };
+    browser.contextMenus.create(menuItemParams, onCreated);
+}
 
 function closeTabs(sender, tabs) {
     var senderFound = false;


### PR DESCRIPTION
Hi @mkopec first of all thank you for creating this extension. 

I have followed your template and essentially created another extension that restores the "Close Other Tabs" item in the root menu. Originally I forked and added another menu item to your extension only to realize that [Firefox just lumps the two items into a submenu](https://bugzilla.mozilla.org/show_bug.cgi?id=1294429), which defeats the purpose of restoring the original items in root context menu.

So this really isn't a PR to be merged, but really to be created as a separate extension. I have written my code in a way such that you will be able to merge the code base of all of your tab management extensions. 

I will be happy to publish this separate extension on the add-ons store myself with your permission, or you can publish it under your account. 
