### PR TITLE
Added pt_BR translation.

### DIFF
--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -1,0 +1,16 @@
+{
+  "extensionName": {
+    "message": "Fechar abas à direita",
+    "description": "Nome da extensão."
+  },
+
+  "extensionDescription": {
+    "message": "Adicione um item no menu de contexto ao clicar o com botão direito sobre uma aba. A extensão adiciona um item de menu para fechar as abas à direita da aba clicada.",
+    "description": "Descrição da extensão."
+  },
+
+  "contextItemTitle": {
+      "message": "Fechar abas à dire&ita",
+      "description": "Título do item no menu de contexto."
+  }
+}


### PR DESCRIPTION
Hi! Loved the extension. I want do contribute with the Brazilian Portuguese translation in this pull request. The PR contains the "pt_BR" folder and the translated messages.json file. I've tested using about:debugging and it worked fine. Thanks in advance and congratulations!